### PR TITLE
Some tweaks in the example details page

### DIFF
--- a/dictionaria/lib/submission.py
+++ b/dictionaria/lib/submission.py
@@ -130,11 +130,14 @@ class Submission(object):
 
                 for index, (key, label) in enumerate(exlabels.items()):
                     label, with_links = label
-                    if ex.get(key):
+                    value = ex.get(key)
+                    if value:
+                        if type(value) == list:
+                            value = '\t'.join(e or '' for e in value)
                         DBSession.add(common.Sentence_data(
                             object_pk=obj.pk,
                             key=label.replace('_', ' '),
-                            value=ex[key]))
+                            value=value))
 
         elif self.dir.joinpath('processed', 'examples.sfm').exists():
             for i, ex in enumerate(

--- a/dictionaria/templates/dutil.mako
+++ b/dictionaria/templates/dutil.mako
@@ -31,6 +31,11 @@
 % endfor
 </%def>
 
+<%def name="format_sentence_data(key, value)">
+    <% value = '; '.join(filter(None, value.split('\t'))) %>
+    <dt>${key}</dt>
+    <dd>${value}</dd>
+</%def>
 
 <%def name="sentence(obj, fmt='long')">
     ${h.rendered_sentence(obj, fmt=fmt)}
@@ -66,8 +71,7 @@
             <dd>${obj.type}</dd>
         % endif
         % for k, v in obj.datadict().items():
-            <dt>${k}</dt>
-            <dd>${v}</dd>
+            ${format_sentence_data(k, v)}
         % endfor
     </dl>
 </%def>

--- a/dictionaria/templates/dutil.mako
+++ b/dictionaria/templates/dutil.mako
@@ -71,7 +71,9 @@
             <dd>${obj.type}</dd>
         % endif
         % for k, v in obj.datadict().items():
+            % if k not in ('Gloss POS', 'Lexical Entries'):
             ${format_sentence_data(k, v)}
+            % endif
         % endfor
     </dl>
 </%def>


### PR DESCRIPTION
 * Format array fields properly (a.k.a. no more `{NULL, a, "b c", d}`)
 * Hide `Gloss_POS` and `Lexical_Entries` column for now