### PR TITLE
word details: display refs and backrefs

### DIFF
--- a/dictionaria/models.py
+++ b/dictionaria/models.py
@@ -128,7 +128,7 @@ class Word(CustomModelMixin, common.Unit, SourcesForDataMixin):
             yield desc, [a.target for a in assocs]
 
     @property
-    def relations(self):
+    def iterrelations(self):
         to_assocs = sorted(self.target_assocs, key=lambda a: a.ord)
         links_to = [
             (ta.description, ta.target)

--- a/dictionaria/models.py
+++ b/dictionaria/models.py
@@ -114,20 +114,6 @@ class Word(CustomModelMixin, common.Unit, SourcesForDataMixin):
         return HTML.span(*args, **{'class': 'lemma'})
 
     @property
-    def linked_from(self):
-        for desc, assocs in groupby(
-                sorted(self.source_assocs, key=lambda a: a.ord),
-                lambda s: s.description):
-            yield RELATIONS.get(desc, desc), [a.source for a in assocs]
-
-    @property
-    def links_to(self):
-        for desc, assocs in groupby(
-                sorted(self.target_assocs, key=lambda a: a.ord),
-                lambda s: s.description):
-            yield desc, [a.target for a in assocs]
-
-    @property
     def iterrelations(self):
         to_assocs = sorted(self.target_assocs, key=lambda a: a.ord)
         links_to = [

--- a/dictionaria/templates/dutil.mako
+++ b/dictionaria/templates/dutil.mako
@@ -186,7 +186,7 @@
     % endfor
     ${'</ul>' if len(ctx.meanings) <= 1 else '</ol>'|n}
 
-    <% rels = list(chain(ctx.links_to)) or list(chain(ctx.linked_from)) %>
+    <% rels = list(ctx.relations) %>
     % if rels:
         <h4>Related entries</h4>
         <ul>

--- a/dictionaria/templates/dutil.mako
+++ b/dictionaria/templates/dutil.mako
@@ -186,7 +186,7 @@
     % endfor
     ${'</ul>' if len(ctx.meanings) <= 1 else '</ol>'|n}
 
-    <% rels = list(ctx.relations) %>
+    <% rels = list(ctx.iterrelations) %>
     % if rels:
         <h4>Related entries</h4>
         <ul>


### PR DESCRIPTION
Word details page only showed references to another entry *or* references from another entry.  It now does both.